### PR TITLE
[nemo-qml-plugin-email] Expose encryption status.

### DIFF
--- a/src/attachmentlistmodel.cpp
+++ b/src/attachmentlistmodel.cpp
@@ -299,7 +299,11 @@ void AttachmentListModel::resetModel()
     m_attachmentFileWatcher = new QFileSystemWatcher(this);
 
     connect(m_attachmentFileWatcher, &QFileSystemWatcher::directoryChanged, this, [this]() {
-        for (const QMailMessagePart::Location &location : m_message.findAttachmentLocations()) {
+        const QList<QMailMessagePart::Location> locations
+            = m_message.isEncrypted()
+            ? QList<QMailMessagePart::Location>() << m_message.partAt(1).location()
+            : m_message.findAttachmentLocations();
+        for (const QMailMessagePart::Location &location : locations) {
             QString attachmentLocation = location.toString(true);
             QString path = attachmentPath(m_message, attachmentLocation);
             if (!path.isEmpty()) {
@@ -309,7 +313,11 @@ void AttachmentListModel::resetModel()
     });
 
     if (m_messageId.isValid()) {
-        for (const QMailMessagePart::Location &location : m_message.findAttachmentLocations()) {
+        const QList<QMailMessagePart::Location> locations
+            = m_message.isEncrypted()
+            ? QList<QMailMessagePart::Location>() << m_message.partAt(1).location()
+            : m_message.findAttachmentLocations();
+        for (const QMailMessagePart::Location &location : locations) {
             Attachment *item = new Attachment;
             item->location = location.toString(true);
             QString dlFolder = downloadFolder(m_message, item->location);

--- a/src/emailmessage.h
+++ b/src/emailmessage.h
@@ -28,6 +28,7 @@ class Q_DECL_EXPORT EmailMessage : public QObject
     Q_ENUMS(AttachedDataStatus)
     Q_ENUMS(CryptoProtocol)
     Q_ENUMS(SignatureStatus)
+    Q_ENUMS(EncryptionStatus)
 
     Q_PROPERTY(int accountId READ accountId NOTIFY accountIdChanged)
     Q_PROPERTY(QString accountAddress READ accountAddress NOTIFY accountAddressChanged)
@@ -47,6 +48,7 @@ class Q_DECL_EXPORT EmailMessage : public QObject
     Q_PROPERTY(bool autoVerifySignature READ autoVerifySignature WRITE setAutoVerifySignature NOTIFY autoVerifySignatureChanged)
     Q_PROPERTY(CryptoProtocol cryptoProtocol READ cryptoProtocol NOTIFY cryptoProtocolChanged)
     Q_PROPERTY(SignatureStatus signatureStatus READ signatureStatus NOTIFY signatureStatusChanged FINAL)
+    Q_PROPERTY(EncryptionStatus encryptionStatus READ encryptionStatus NOTIFY encryptionStatusChanged FINAL)
     Q_PROPERTY(QDateTime date READ date NOTIFY storedMessageChanged)
     Q_PROPERTY(QString from READ from WRITE setFrom NOTIFY fromChanged)
     Q_PROPERTY(QString fromAddress READ fromAddress NOTIFY fromChanged)
@@ -113,6 +115,11 @@ public:
         SignedFailure
     };
 
+    enum EncryptionStatus {
+        NoDigitalEncryption,
+        Encrypted
+    };
+
     enum CryptoProtocol {
         UnknownProtocol,
         OpenPGP,
@@ -148,6 +155,7 @@ public:
     bool autoVerifySignature() const;
     CryptoProtocol cryptoProtocol() const;
     SignatureStatus signatureStatus() const;
+    EncryptionStatus encryptionStatus() const;
     QDateTime date() const;
     QString from() const;
     QString fromAddress() const;
@@ -211,6 +219,7 @@ signals:
     void autoVerifySignatureChanged();
     void cryptoProtocolChanged();
     void signatureStatusChanged();
+    void encryptionStatusChanged();
     void dateChanged();
     void fromChanged();
     void htmlBodyChanged();
@@ -265,6 +274,7 @@ private:
     void updateReadReceiptHeader();
     QString readReceiptRequestEmail() const;
     void setSignatureStatus(SignatureStatus status);
+    void setEncryptionStatus(EncryptionStatus status);
 
     QMailAccount m_account;
     QStringList m_attachments;
@@ -287,6 +297,7 @@ private:
     SignatureStatus m_signatureStatus;
     QMailCryptoFwd::VerificationResult m_cryptoResult;
     QString m_signatureLocation;
+    EncryptionStatus m_encryptionStatus;
 };
 
 #endif

--- a/src/emailmessagelistmodel.cpp
+++ b/src/emailmessagelistmodel.cpp
@@ -61,6 +61,7 @@ EmailMessageListModel::EmailMessageListModel(QObject *parent)
     roles[MessageHasAttachmentsRole] = "hasAttachments";
     roles[MessageHasCalendarInvitationRole] = "hasCalendarInvitation";
     roles[MessageHasSignatureRole] = "hasSignature";
+    roles[MessageIsEncryptedRole] = "isEncrypted";
     roles[MessageSizeSectionRole] = "sizeSection";
     roles[MessageFolderIdRole] = "folderId";
     roles[MessageParsedSubject] = "parsedSubject";
@@ -218,6 +219,8 @@ QVariant EmailMessageListModel::data(const QModelIndex & index, int role) const
         return (messageMetaData.status() & QMailMessageMetaData::CalendarInvitation) != 0;
     } else if (role == MessageHasSignatureRole) {
         return (messageMetaData.status() & QMailMessageMetaData::HasSignature) != 0;
+    } else if (role == MessageIsEncryptedRole) {
+        return (messageMetaData.status() & QMailMessageMetaData::HasEncryption) != 0;
     } else if (role == MessageSizeSectionRole) {
         const uint size(messageMetaData.size());
 

--- a/src/emailmessagelistmodel.h
+++ b/src/emailmessagelistmodel.h
@@ -68,6 +68,7 @@ public:
         MessageHasAttachmentsRole,                             // returns 1 if message has attachments, 0 otherwise
         MessageHasCalendarInvitationRole,                      // returns 1 if message has a calendar invitation, 0 otherwise
         MessageHasSignatureRole,                               // returns true if message is numerically signed, false otherwise
+        MessageIsEncryptedRole,                               // returns true if message is numerically encrypted, false otherwise
         MessageSizeSectionRole,                                // returns size section (0-2)
         MessageFolderIdRole,                                   // returns parent folder id for the message
         MessageParsedSubject,                                  // returns the message subject parsed against a pre-defined regular expression


### PR DESCRIPTION
It's based on https://codereview.qt-project.org/c/qt-labs/messagingframework/+/499122

@pvuorela , the main idea is not for the moment to bring decryption capabilities, but to let the power users to do something with encrypted emails, and also to mention to normal users that the email content is not displayed because of encryption.

Indeed, currently, an encrypted email simply display a blank page, without any information. With the current PR, the encryption status is exposed to QML and the application can be tuned accordingly.

Later on, the EncryptionStatus can be expanded a bit when decryption capabilities will be added to QMF, mentioning potential issues on decryption… That's why I didn't made it a boolean.