### PR TITLE
[nemo-qml-plugin-email] Return empty attachment URL if the file does not exist.

### DIFF
--- a/src/attachmentlistmodel.cpp
+++ b/src/attachmentlistmodel.cpp
@@ -111,7 +111,7 @@ QVariant AttachmentListModel::data(const QModelIndex &index, int role) const
     } else if (role == Type) {
         return attachmentType(item->part);
     } else if (role == Url) {
-        return item->url;
+        return (!item->url.isEmpty() && QFile::exists(item->url.mid(7))) ? item->url : QString();
     } else if (role == ProgressInfo) {
         return item->progressInfo;
     }


### PR DESCRIPTION
    Previously, opening again an attachment
    that has been deleted didn't trigger the
    saving of the attachment since the url
    was always containing the saved location.
    
    With this change, the return URL is set
    to an empty string if the saved file has
    been deleted.

@pvuorela , this is a different proposition based on the URL getter. It's much simpler than a full blown FileWatcher solution. The only drawback is the lack of notification when the URL becomes invalid. But since it is used in JS code only in the UI, this could be fine. If you would prefer a solution based on a FileWatcher, I've got one also, using a directory watcher ;-)