### PR TITLE
[nemo-qml-plugin-email] Notify on attachment deletion.

### DIFF
--- a/src/attachmentlistmodel.h
+++ b/src/attachmentlistmodel.h
@@ -11,6 +11,7 @@
 #define EMAILATTACHMENTLISTMODEL_H
 
 #include <QAbstractListModel>
+#include <QFileSystemWatcher>
 #include <qmailmessage.h>
 #include "emailagent.h"
 
@@ -71,6 +72,7 @@ private slots:
     void onAttachmentDownloadProgressChanged(const QString &attachmentLocation, double progress);
     void onAttachmentPathChanged(const QString &attachmentLocation, const QString &path);
     void onMessagesUpdated(const QMailMessageIdList &ids);
+    void onDirectoryChanged(const QString &path);
 
 private:
     QHash<int, QByteArray> roles;
@@ -90,6 +92,7 @@ private:
     };
 
     QList<Attachment*> m_attachmentsList;
+    QFileSystemWatcher *m_attachmentFileWatcher;
 
     void resetModel();
 


### PR DESCRIPTION
In the attachment list model, notify url
change if one attachment is deleted from
disk.

Previously, opening again an attachment
that has been deleted didn't trigger the
saving of the attachment since the url
was not cleared on deletion.

@pvuorela, for reference, this is the solution with the FileWatcher, allowing a proper notification when the URL changes.