### PR TITLE
[nemo-qml-plugin-email] expose replied, repliedAll and forwarded status

### DIFF
--- a/src/emailmessagelistmodel.cpp
+++ b/src/emailmessagelistmodel.cpp
@@ -66,6 +66,9 @@ EmailMessageListModel::EmailMessageListModel(QObject *parent)
     roles[MessageParsedSubject] = "parsedSubject";
     roles[MessageTrimmedSubject] = "trimmedSubject";
     roles[MessageHasCalendarCancellationRole] = "hasCalendarCancellation";
+    roles[MessageRepliedRole] = "replied";
+    roles[MessageRepliedAllRole] = "repliedAll";
+    roles[MessageForwardedRole] = "forwarded";
 
     m_key = key();
     m_sortKey = QMailMessageSortKey::timeStamp(Qt::DescendingOrder);
@@ -242,6 +245,12 @@ QVariant EmailMessageListModel::data(const QModelIndex & index, int role) const
         return subject.replace(QRegExp(QStringLiteral("^(re:|fw:|fwd:|\\s*)*"), Qt::CaseInsensitive), QString());
     } else if (role == MessageHasCalendarCancellationRole) {
         return (messageMetaData.status() & QMailMessageMetaData::CalendarCancellation) != 0;
+    } else if (role == MessageRepliedRole) {
+        return (messageMetaData.status() & QMailMessageMetaData::Replied) != 0;
+    } else if (role == MessageRepliedAllRole) {
+        return (messageMetaData.status() & QMailMessageMetaData::RepliedAll) != 0;
+    } else if (role == MessageForwardedRole) {
+        return (messageMetaData.status() & QMailMessageMetaData::Forwarded) != 0;
     }
 
     return QMailMessageListModel::data(index, role);

--- a/src/emailmessagelistmodel.h
+++ b/src/emailmessagelistmodel.h
@@ -73,6 +73,9 @@ public:
         MessageParsedSubject,                                  // returns the message subject parsed against a pre-defined regular expression
         MessageTrimmedSubject,                                 // returns the message subject without Re: and Fwd: prefixes
         MessageHasCalendarCancellationRole,                    // returns 1 if message has a calendar cancellation, 0 otherwise
+        MessageRepliedRole,                                    // returns 1 if message has been replied to, 0 otherwise
+        MessageRepliedAllRole,                                 // returns 1 if message has been replied to all, 0 otherwise
+        MessageForwardedRole,                                  // returns 1 if message has been forwarded, 0 otherwise
     };
 
     enum Priority { LowPriority, NormalPriority, HighPriority };


### PR DESCRIPTION
Imap can transport the information if a message has been replied to, replied to all or forwarded. jolla-email unfortunately does not expose this currently. It would be really helpful to have this to be able to quickly check if I still need to answer some mail.

In order to display this in the ui, apply the following changes to /usr/share/jolla-email/pages/MessageItem.qml starting line 129
```
                HighlightImage {
                    visible: model.replied
                    source: "image://theme/icon-s-replied?"
                }
```

Open questions:

- [ ] `icon-s-replied?` does not exist, is there a list of icons somewhere?
- [ ] if I change it to `icon-s-certificates?`, it is still not displayed, why?
- [ ] how do I do a PR to jolla-email? NDA?