### PR TITLE
[nemo-qml-plugin-email] Set the response type on send, if any.

### DIFF
--- a/src/emailmessage.cpp
+++ b/src/emailmessage.cpp
@@ -332,6 +332,27 @@ void EmailMessage::sendBuiltMessage()
         // Send messages are always new at this point
         m_newMessage = false;
         emitSignals();
+
+        if (m_msg.inResponseTo().isValid()) {
+            const QString description = QString::fromLatin1("Marking message as replied/forwared");
+            switch (m_msg.responseType()) {
+            case (QMailMessage::Reply):
+                QMailDisconnected::flagMessage(m_msg.inResponseTo(),
+                                               QMailMessage::Replied, 0, description);
+                break;
+            case (QMailMessage::ReplyToAll):
+                QMailDisconnected::flagMessage(m_msg.inResponseTo(),
+                                               QMailMessage::RepliedAll, 0, description);
+                break;
+            case (QMailMessage::Forward):
+            case (QMailMessage::ForwardPart):
+                QMailDisconnected::flagMessage(m_msg.inResponseTo(),
+                                               QMailMessage::Forwarded, 0, description);
+                break;
+            default:
+                break;
+            }
+        }
     } else {
        qCWarning(lcEmail) << "Error: queuing message, stored:" << stored;
     }


### PR DESCRIPTION
When an email is queued for sending, set the
response flag in the status of the original
message if the sent message is a reply or a
forward.

@pvuorela, another possibility, after discussion on https://codereview.qt-project.org/c/qt-labs/messagingframework/+/520569 where the response flag is set when an email is queued for sending.