### PR TITLE
[nemo-qml-plugin-email] Add a getter to attachment sizes.

### DIFF
--- a/src/attachmentlistmodel.cpp
+++ b/src/attachmentlistmodel.cpp
@@ -248,6 +248,11 @@ QString AttachmentListModel::location(int idx)
     return data(index(idx, 0), ContentLocation).toString();
 }
 
+int AttachmentListModel::size(int idx)
+{
+    return data(index(idx, 0), Size).toInt();
+}
+
 int AttachmentListModel::count() const
 {
     return rowCount();

--- a/src/attachmentlistmodel.h
+++ b/src/attachmentlistmodel.h
@@ -36,8 +36,7 @@ public:
         Title, // subject for attached emails when available, currently empty otherwise
         Type,
         Url,
-        ProgressInfo,
-        Index
+        ProgressInfo
     };
 
     enum AttachmentType {

--- a/src/attachmentlistmodel.h
+++ b/src/attachmentlistmodel.h
@@ -55,6 +55,7 @@ public:
     Q_INVOKABLE AttachmentType type(int idx);
     Q_INVOKABLE QString url(int idx);
     Q_INVOKABLE QString location(int idx);
+    Q_INVOKABLE int size(int idx);
 
     int count() const;
     int messageId() const;


### PR DESCRIPTION
This property should be used in a for loop in EmailComposer.qml.

When re-editing a draft with an attachment, opening the attachment page raises a warning for a non existent `fileSize` property in the model. This is due to the fact that the model in this QML page is not an `Email.AttachmentListModel` but a plain QML `ListModel`, populated in the EmailComposer.qml page from an `Email.AttachmentListModel`, while the `size` property of the latter is not propagated to the former (under the name `fileSize`).