### PR TITLE
[nemo-qml-plugin-email] Simplify body creation.

### DIFF
--- a/src/emailmessage.cpp
+++ b/src/emailmessage.cpp
@@ -1142,9 +1142,6 @@ QStringList EmailMessage::to() const
 // ############## Private API #########################
 void EmailMessage::buildMessage(QMailMessage *msg)
 {
-    // remove all existent message parts if there's any
-    msg->clearParts();
-
     if (msg->responseType() == QMailMessage::Reply || msg->responseType() == QMailMessage::ReplyToAll ||
             msg->responseType() == QMailMessage::Forward) {
         // Needed for conversations support
@@ -1164,14 +1161,7 @@ void EmailMessage::buildMessage(QMailMessage *msg)
         type.setSubType("html");
     */
     // This should be improved to use QuotedPrintable when appending parts and inline references are implemented
-    if (m_attachments.size() == 0) {
-        msg->setBody(QMailMessageBody::fromData(m_bodyText, type, QMailMessageBody::Base64));
-    } else {
-        QMailMessagePart body;
-        body.setBody(QMailMessageBody::fromData(m_bodyText.toUtf8(), type, QMailMessageBody::Base64));
-        msg->setMultipartType(QMailMessagePartContainer::MultipartMixed);
-        msg->appendPart(body);
-    }
+    msg->setBody(QMailMessageBody::fromData(m_bodyText, type, QMailMessageBody::Base64));
 
     // Include attachments into the message
     if (m_attachments.size()) {


### PR DESCRIPTION
Adding attachment already move the body
to a first part and set a multipart/mixed
content type, in the QMF code.

@pvuorela, still looking on attachment code, I've noticed that some code were duplicated between QMF and the nemo plugin. But, it's a bit tricky in the sense, that `setAttachments()` actually changes the multipart to multipart/mixed and clear the existing parts. Which is basically what was done in the plugin. But the clear parts in the plugin was done _before_ setting the body. From my understanding, this should not have any impact. Tests also show no regression (creating a draft with attachment, then reediting the draft to remove the attachment for instance). But I'm not 100% sure because of the slightly different code path and QMF being quite a complex code.

Another question also: I needed to add the change of attachment flag because removing the attachments from a draft didn't remove the icon in the email list (already existing bug). I think, this does not belong to here and should be done at QMF level, since setting the flag is done at QMF level by the call to setAttachments(). But I'm not completely sure where to put it. It seems to me that it should be in ::setBody(). Looking at the code there, I've noticed that you can set a body to a partcontainer that already contains parts (_messageParts is non empty), which is basically what we're doing when removing the attachments of draft with attachments. In that case, the _messageParts is not cleared, and you can still have ::hasBody() that is true and ::partCount() that is strictly greater than 0. Which is inconsistent as far as I can say. Do you agree with me ? Should I provide a patch in QMF that empties the parts when setting a non empty body (and as a consequence unset the attachment flag) ?