### PR TITLE
[nemo-qml-plugin-email] Fix initial download status.

### DIFF
--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -187,7 +187,7 @@ EmailAgent::AttachmentStatus EmailAgent::attachmentDownloadStatus(const QMailMes
     } else {
         QString checksum;
         const QString path = attachmentFilename(message, attachmentLocation, &checksum);
-        bool matches = matchesAttachment(attachmentLocation, checksum);
+        bool matches = matchesAttachment(path, checksum);
         if (downloadPath && matches) {
             *downloadPath = path;
         }


### PR DESCRIPTION
Because of a mistake, the initial state
was always NotDownloaded. The issue was
shadowed though by the fact that
downloadAttachment() was flipping the
status to Downloaded when noticing the
presence of the file on disk.

@pvuorela , I'm sorry for the mistake. I noticed it today, still trying to make encrypted emails working with attachments. It seems to be harmless though, as mentioned in the commit message.