### PR TITLE
[nemo-qml-plugin-email] Move attachment model has a property of Email.

### DIFF
--- a/src/attachmentlistmodel.h
+++ b/src/attachmentlistmodel.h
@@ -15,15 +15,15 @@
 #include <qmailmessage.h>
 #include "emailagent.h"
 
+class EmailMessage;
 class Q_DECL_EXPORT AttachmentListModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged)
-    Q_PROPERTY(int messageId READ messageId WRITE setMessageId NOTIFY messageIdChanged FINAL)
     Q_ENUMS(AttachmentType);
 
 public:
-    explicit AttachmentListModel(QObject *parent = 0);
+    explicit AttachmentListModel(EmailMessage *parent);
     ~AttachmentListModel();
 
     enum Role {
@@ -44,6 +44,19 @@ public:
         Other
     };
 
+    struct Attachment {
+        QString location;
+        QString displayName;
+        bool downloaded = false;
+        EmailAgent::AttachmentStatus status = EmailAgent::Unknown;
+        QString mimeType;
+        int size = 0;
+        QString title;
+        AttachmentType type = Other;
+        QString url;
+        double progressInfo = 0.;
+    };
+
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     QVariant data(const QModelIndex &index, int role) const;
 
@@ -57,15 +70,12 @@ public:
     Q_INVOKABLE int size(int idx);
 
     int count() const;
-    int messageId() const;
-    void setMessageId(int id);
 
 protected:
     virtual QHash<int, QByteArray> roleNames() const;
 
 signals:
     void countChanged();
-    void messageIdChanged();
 
 private slots:
     void onAttachmentDownloadStatusChanged(const QString &attachmentLocation, EmailAgent::AttachmentStatus status);
@@ -76,26 +86,11 @@ private slots:
 
 private:
     QHash<int, QByteArray> roles;
-    QMailMessageId m_messageId;
-    QMailMessage m_message;
-    struct Attachment {
-        Attachment()
-            : status(EmailAgent::Unknown),
-              progressInfo(0.0)
-        {}
-
-        QMailMessagePart part;
-        QString location;
-        EmailAgent::AttachmentStatus status;
-        QString url;
-        double progressInfo;
-    };
-
-    QList<Attachment*> m_attachmentsList;
+    EmailMessage *m_message;
+    QList<Attachment> m_attachmentsList;
     QFileSystemWatcher *m_attachmentFileWatcher;
 
     void resetModel();
-
 };
 
 Q_DECLARE_METATYPE(AttachmentListModel::AttachmentType)

--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -842,15 +842,20 @@ bool EmailAgent::downloadAttachment(int messageId, const QString &attachmentLoca
 {
     QMailMessageId mailMessageId(messageId);
     QMailMessage message(mailMessageId);
+    return downloadAttachment(&message, attachmentLocation);
+}
+
+bool EmailAgent::downloadAttachment(QMailMessage *message, const QString &attachmentLocation)
+{
     QMailMessagePart::Location location(attachmentLocation);
 
-    if (message.contains(location)) {
-        const QMailMessagePart attachmentPart = message.partAt(location);
+    if (message && message->contains(location)) {
+        const QMailMessagePart attachmentPart = message->partAt(location);
         if (attachmentPart.hasBody()) {
-            return saveAttachmentToDownloads(&message, attachmentLocation);
+            return saveAttachmentToDownloads(message, attachmentLocation);
         } else {
             qCDebug(lcEmail) << "Start Download for:" << attachmentLocation;
-            location.setContainingMessageId(mailMessageId);
+            location.setContainingMessageId(message->id());
             enqueue(new RetrieveMessagePart(m_retrievalAction.data(), location, true));
         }
     } else {

--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -27,7 +27,6 @@
 
 #include "emailagent.h"
 #include "emailaction.h"
-#include "emailutils.h"
 #include "folderutils.h"
 #include "folderaccessor.h"
 #include "logging_p.h"
@@ -194,44 +193,6 @@ EmailAgent::AttachmentStatus EmailAgent::attachmentDownloadStatus(const QMailMes
         return (matches) ? Downloaded : NotDownloaded;
     }
     return Unknown;
-}
-
-QString EmailAgent::attachmentName(const QMailMessagePart &part) const
-{
-    return part.displayName().remove('/');
-}
-
-QString EmailAgent::attachmentTitle(const QMailMessagePart &part) const
-{
-    if (isEmailPart(part)) {
-        if (part.contentAvailable())
-            return QMailMessage::fromRfc2822(part.body().data(QMailMessageBody::Decoded)).subject();
-
-        auto contentType = part.contentType();
-        QString name = contentType.isParameterEncoded("name")
-            ? QMailMessageHeaderField::decodeParameter(contentType.name()).trimmed()
-            : QMailMessageHeaderField::decodeContent(contentType.name()).trimmed();
-
-        // QMF plugin may append an extra .eml ending, remove both
-        for (int i = 0; name.endsWith(EML_EXTENSION) && i < 2; i++)
-            name.chop(4);
-
-        if (!name.isEmpty())
-            return name;
-
-        auto contentDisposition = part.contentDisposition();
-        name = contentDisposition.isParameterEncoded("filename")
-            ? QMailMessageHeaderField::decodeParameter(contentDisposition.filename()).trimmed()
-            : QMailMessageHeaderField::decodeContent(contentDisposition.filename()).trimmed();
-
-        if (name.endsWith(EML_EXTENSION))
-            name.chop(4);
-
-        if (!name.isEmpty())
-            return name;
-    }
-
-    return QString();
 }
 
 QString EmailAgent::bodyPlainText(const QMailMessage &mailMsg) const

--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -96,6 +96,7 @@ public:
     void cancelAction(quint64 actionId);
     quint64 downloadMessages(const QMailMessageIdList &messageIds, QMailRetrievalAction::RetrievalSpecification spec);
     quint64 downloadMessagePart(const QMailMessagePartContainer::Location &location);
+    bool downloadAttachment(QMailMessage *message, const QString &attachmentLocation);
     void exportUpdates(const QMailAccountIdList &accountIdList);
     bool hasMessagesInOutbox(const QMailAccountId &accountId);
     void initMailServer();

--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -90,8 +90,6 @@ public:
                                                           const QString &attachmentLocation,
                                                           QString *downloadPath = nullptr);
     double attachmentDownloadProgress(const QString &attachmentLocation);
-    QString attachmentName(const QMailMessagePart &part) const;
-    QString attachmentTitle(const QMailMessagePart &part) const;
     QString bodyPlainText(const QMailMessage &mailMsg) const;
     void cancelAction(quint64 actionId);
     quint64 downloadMessages(const QMailMessageIdList &messageIds, QMailRetrievalAction::RetrievalSpecification spec);

--- a/src/emailmessage.cpp
+++ b/src/emailmessage.cpp
@@ -560,12 +560,12 @@ AttachmentListModel::Attachment EmailMessage::attachment(const QString &location
         QString path;
         QMailMessagePart part = m_msg.partAt(partLocation);
         attachment.location = location;
-        attachment.displayName = EmailAgent::instance()->attachmentName(part);
+        attachment.displayName = attachmentName(part);
         attachment.downloaded = attachmentPartDownloaded(part);
         attachment.status = EmailAgent::instance()->attachmentDownloadStatus(m_msg, location, &path);
         attachment.mimeType = QString::fromLatin1(part.contentType().content());
         attachment.size = attachmentSize(part);
-        attachment.title = EmailAgent::instance()->attachmentTitle(part);
+        attachment.title = attachmentTitle(part);
         attachment.type = (isEmailPart(part)) ? AttachmentListModel::Email : AttachmentListModel::Other;
         if (!path.isEmpty()) {
             attachment.url = QUrl::fromLocalFile(path).toString();

--- a/src/emailmessage.h
+++ b/src/emailmessage.h
@@ -18,6 +18,7 @@
 #include <qmailcryptofwd.h>
 
 #include "emailagent.h"
+#include "attachmentlistmodel.h"
 
 class Q_DECL_EXPORT EmailMessage : public QObject
 {
@@ -34,6 +35,7 @@ class Q_DECL_EXPORT EmailMessage : public QObject
     Q_PROPERTY(QString accountAddress READ accountAddress NOTIFY accountAddressChanged)
     Q_PROPERTY(int folderId READ folderId NOTIFY folderIdChanged)
     Q_PROPERTY(QStringList attachments READ attachments WRITE setAttachments NOTIFY attachmentsChanged)
+    Q_PROPERTY(AttachmentListModel* attachmentModel READ attachmentModel CONSTANT)
     Q_PROPERTY(QStringList bcc READ bcc WRITE setBcc NOTIFY bccChanged)
     Q_PROPERTY(QString body READ body WRITE setBody NOTIFY bodyChanged)
     Q_PROPERTY(QString calendarInvitationUrl READ calendarInvitationUrl NOTIFY calendarInvitationUrlChanged FINAL)
@@ -128,6 +130,8 @@ public:
 
     Q_INVOKABLE void cancelMessageDownload();
     Q_INVOKABLE void downloadMessage();
+    Q_INVOKABLE void cancelAttachmentDownload(const QString &location);
+    Q_INVOKABLE bool downloadAttachment(const QString &location);
     Q_INVOKABLE void getCalendarInvitation();
     Q_INVOKABLE void loadFromFile(const QString &path);
     Q_INVOKABLE void send();
@@ -141,6 +145,7 @@ public:
     QString accountAddress() const;
     int folderId() const;
     QStringList attachments();
+    AttachmentListModel* attachmentModel();
     QStringList bcc() const;
     QString body();
     QString calendarInvitationUrl();
@@ -199,6 +204,8 @@ public:
     QString subject();
     QStringList to() const;
     QStringList toEmailAddresses() const;
+    QStringList attachmentLocations() const;
+    AttachmentListModel::Attachment attachment(const QString &location) const;
 
 signals:
     void sendEnqueued(bool success);
@@ -298,6 +305,7 @@ private:
     QMailCryptoFwd::VerificationResult m_cryptoResult;
     QString m_signatureLocation;
     EncryptionStatus m_encryptionStatus;
+    AttachmentListModel *m_attachmentModel = nullptr;
 };
 
 #endif

--- a/src/emailutils.h
+++ b/src/emailutils.h
@@ -22,6 +22,44 @@ inline bool isEmailPart(const QMailMessagePart &part)
     return false;
 }
 
+inline QString attachmentName(const QMailMessagePart &part)
+{
+    return part.displayName().remove('/');
+}
+
+inline QString attachmentTitle(const QMailMessagePart &part)
+{
+    if (isEmailPart(part)) {
+        if (part.contentAvailable())
+            return QMailMessage::fromRfc2822(part.body().data(QMailMessageBody::Decoded)).subject();
+
+        auto contentType = part.contentType();
+        QString name = contentType.isParameterEncoded("name")
+            ? QMailMessageHeaderField::decodeParameter(contentType.name()).trimmed()
+            : QMailMessageHeaderField::decodeContent(contentType.name()).trimmed();
+
+        // QMF plugin may append an extra .eml ending, remove both
+        for (int i = 0; name.endsWith(EML_EXTENSION) && i < 2; i++)
+            name.chop(4);
+
+        if (!name.isEmpty())
+            return name;
+
+        auto contentDisposition = part.contentDisposition();
+        name = contentDisposition.isParameterEncoded("filename")
+            ? QMailMessageHeaderField::decodeParameter(contentDisposition.filename()).trimmed()
+            : QMailMessageHeaderField::decodeContent(contentDisposition.filename()).trimmed();
+
+        if (name.endsWith(EML_EXTENSION))
+            name.chop(4);
+
+        if (!name.isEmpty())
+            return name;
+    }
+
+    return QString();
+}
+
 inline int attachmentSize(const QMailMessagePart &part)
 {
     if (part.contentDisposition().size() != -1) {

--- a/src/emailutils.h
+++ b/src/emailutils.h
@@ -22,4 +22,22 @@ inline bool isEmailPart(const QMailMessagePart &part)
     return false;
 }
 
+inline int attachmentSize(const QMailMessagePart &part)
+{
+    if (part.contentDisposition().size() != -1) {
+        return part.contentDisposition().size();
+    }
+    // If size is -1 (unknown) try finding out part's body size
+    if (part.contentAvailable()) {
+        return part.hasBody() ? part.body().length() : 0;
+    }
+    return -1;
+}
+
+inline bool attachmentPartDownloaded(const QMailMessagePart &part)
+{
+    // Addresses the case where content size is missing
+    return part.contentAvailable() || part.contentDisposition().size() <= 0;
+}
+
 #endif

--- a/src/plugin/plugin.cpp
+++ b/src/plugin/plugin.cpp
@@ -83,7 +83,8 @@ public:
         qmlRegisterType<EmailAccountSettingsModel>(uri, 0, 1, "EmailAccountSettingsModel");
         qmlRegisterType<EmailAccount>(uri, 0, 1, "EmailAccount");
         qmlRegisterType<EmailFolder>(uri, 0, 1, "EmailFolder");
-        qmlRegisterType<AttachmentListModel>(uri, 0, 1, "AttachmentListModel");
+        qmlRegisterUncreatableType<AttachmentListModel>(uri, 0, 1, "AttachmentListModel",
+                                                        "AttachmentListModel is got from a EmailMessage");
         qmlRegisterUncreatableType<FolderAccessor>(uri, 0, 1, "FolderAccessor",
                                                    "FolderAccessor is created via FolderListModel or similar");
     }


### PR DESCRIPTION
With decryption on the fly, decrypted mail
structure will never be saved to the mail
store. It thus requires for part with
attachments to be linked to the decrypted
Email object and not fetched from mail
store anymore.

EmailAgent::downloadAttachment() with a
messageId is thus replaced by a new
EmailMessage::downloadAttachment().

AttachmentListModel, previously based on
a messageId, has been modified to become
a property of an EmailMessage object.

@pvuorela, not in a hurry at all. Just publishing early so you can give me feedback on the intent when you have time to. This PR reworks the attachment model for changes coming with decryption. Indeed, as mentioned in the commit message, decrypted messages are not saved in mail store. So everything that reload the current message, displayed in the UI, from its messageId will not work with decrypted messages.
- The body of the message can easily be changed on decryption inside an EmailMessage object and signals emitted accordingly.
- But attachments are currently handled by a list model based on a messageId. So decrypted attachments are not displayed. There are different ways to handle this, but I choose to modify the attachment list model not to be based on a messageId anymore but being a property of an EmailMessage. It then allows to deal with dynamic changes of the EmailMessage object itself.
- Tapping on an attachment in the UI, also calls `downloadAttachment()` from the email agent. Which in turns reload the message from the mail store to see if the attachment is already available. This is changed in favour of an invocable method in EmailMessage, which can pass its internal QMailMessage to the email agent, instead of reloading it.

I'm currently testing these changes to see if there is any regression. So far it seems to work well with POP3. But I prefer to give it some time, and also to test more extensively IMAP4.

One side effect of this move is to consume less memory in the attachment list model, which was duplicating in memory the full QMailMessage (including in memory content of all the attachments) as `m_message` and also each QMailMessagePart (with the in-memory attachments) in the `Attacment::part` attributes.

It is a change of API, so it requires some changes in jolla-email, that I'm addressing in a dedicated PR.