### PR TITLE
[nemo-qml-plugin-email] Add decryption capability to EmailMessage.

### DIFF
--- a/rpm/nemo-qml-plugin-email-qt5.spec
+++ b/rpm/nemo-qml-plugin-email-qt5.spec
@@ -1,6 +1,6 @@
 Name:       nemo-qml-plugin-email-qt5
 Summary:    Email plugin for Nemo Mobile
-Version:    0.6.22
+Version:    0.6.36
 Release:    1
 License:    ASL 2.0 and LGPLv2+ and BSD
 URL:        https://github.com/sailfishos/nemo-qml-plugin-email
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(QmfMessageServer) >= 4.0.4+git127
-BuildRequires:  pkgconfig(QmfClient) >= 4.0.4+git127
+BuildRequires:  pkgconfig(QmfClient) >= 4.0.4+git146
 BuildRequires:  pkgconfig(accounts-qt5)
 Conflicts: nemo-qml-plugin-email-qt5-offline
 

--- a/src/emailmessage.h
+++ b/src/emailmessage.h
@@ -119,7 +119,11 @@ public:
 
     enum EncryptionStatus {
         NoDigitalEncryption,
-        Encrypted
+        Encrypted,
+        EncryptedDataDownloading,
+        EncryptedDataMissing,
+        Decrypting,
+        DecryptionFailure
     };
 
     enum CryptoProtocol {
@@ -138,6 +142,7 @@ public:
     Q_INVOKABLE bool sendReadReceipt(const QString &subjectPrefix, const QString &readReceiptBodyText);
     Q_INVOKABLE void saveDraft();
     Q_INVOKABLE void verifySignature();
+    Q_INVOKABLE void decrypt();
     Q_INVOKABLE SignatureStatus getSignatureStatusForKey(const QString &keyIdentifier) const;
     Q_INVOKABLE CryptoProtocol cryptoProtocolForKey(const QString &pluginName, const QString &keyIdentifier) const;
 
@@ -304,6 +309,7 @@ private:
     SignatureStatus m_signatureStatus;
     QMailCryptoFwd::VerificationResult m_cryptoResult;
     QString m_signatureLocation;
+    QString m_cryptedDataLocation;
     EncryptionStatus m_encryptionStatus;
     AttachmentListModel *m_attachmentModel = nullptr;
 };


### PR DESCRIPTION
@pvuorela this PR shows how decryption (with or without attachments) can work.

It requires https://codereview.qt-project.org/c/qt-labs/messagingframework/+/499749 to be accepted first. But I'm providing this PR also to show the complete picture.