### PR TITLE
[nemo-qml-plugin-email] Use new upstream functions to get crypto settings.

### DIFF
--- a/rpm/nemo-qml-plugin-email-qt5.spec
+++ b/rpm/nemo-qml-plugin-email-qt5.spec
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(QmfMessageServer) >= 4.0.4+git127
-BuildRequires:  pkgconfig(QmfClient) >= 4.0.4+git146
+BuildRequires:  pkgconfig(QmfClient) >= 4.0.4+git156
 BuildRequires:  pkgconfig(accounts-qt5)
 Conflicts: nemo-qml-plugin-email-qt5-offline
 

--- a/src/emailaccountlistmodel.cpp
+++ b/src/emailaccountlistmodel.cpp
@@ -10,6 +10,7 @@
 
 #include <qmailstore.h>
 #include <qmailnamespace.h>
+#include <qmailcrypto.h>
 
 #include "emailaccountlistmodel.h"
 #include "logging_p.h"
@@ -107,6 +108,21 @@ QVariant EmailAccountListModel::data(const QModelIndex &index, int role) const
         return m_unreadCountCache.value(accountId);
     }
 
+    if (role == CryptoSignatureType) {
+        QMailAccountConfiguration config(accountId);
+        return QMailCryptographicServiceConfiguration(&config).signatureType();
+    }
+
+    if (role == CryptoSignatureIds) {
+        QMailAccountConfiguration config(accountId);
+        return QMailCryptographicServiceConfiguration(&config).signatureKeys();
+    }
+
+    if (role == UseCryptoSignatureByDefault) {
+        QMailAccountConfiguration config(accountId);
+        return QMailCryptographicServiceConfiguration(&config).useSignatureByDefault();
+    }
+
     QMailAccount account(accountId);
 
     if (role == EmailAddress) {
@@ -149,18 +165,6 @@ QVariant EmailAccountListModel::data(const QModelIndex &index, int role) const
 
     if (role == HasPersistentConnection) {
         return (account.status() & QMailAccount::HasPersistentConnection) != 0;
-    }
-
-    if (role == CryptoSignatureType) {
-        return account.cryptoSignatureType();
-    }
-
-    if (role == CryptoSignatureIds) {
-        return account.cryptoSignatureIds();
-    }
-
-    if (role == UseCryptoSignatureByDefault) {
-        return (account.status() & QMailAccount::UseCryptoSignatureByDefault) != 0;
     }
 
     return QVariant();


### PR DESCRIPTION
These settings were exposed by a patch on
QMailAccount. Upstream QMF is now providing
a new class for this.