### PR TITLE
[nemo-email] Install tests without extra container directory. JB#54138

### DIFF
--- a/rpm/nemo-qml-plugin-email-qt5-offline.spec
+++ b/rpm/nemo-qml-plugin-email-qt5-offline.spec
@@ -43,7 +43,7 @@ Requires:   %{name} = %{version}-%{release}
 echo "DEFINES+=OFFLINE" > .qmake.conf
 %qmake5 "VERSION=%{version}" "DEFINES+=OFFLINE"
 
-make %{?_smp_mflags}
+%make_build
 
 %install
 %qmake5_install
@@ -58,7 +58,6 @@ sed 's/Nemo.Email/org.nemomobile.email/' < src/plugin/qmldir > %{buildroot}%{_li
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license LICENSE.ASL2 LICENSE.LGPL LICENSE.BSD
 %{_libdir}/libnemoemail-qt5.so.*
 %dir %{_libdir}/qt5/qml/Nemo/Email
@@ -75,12 +74,10 @@ sed 's/Nemo.Email/org.nemomobile.email/' < src/plugin/qmldir > %{buildroot}%{_li
 %{_libdir}/qt5/qml/org/nemomobile/email/qmldir
 
 %files devel
-%defattr(-,root,root,-)
 %{_libdir}/libnemoemail-qt5.so
 %{_libdir}/libnemoemail-qt5.prl
 %{_includedir}/nemoemail-qt5/*.h
 %{_libdir}/pkgconfig/nemoemail-qt5.pc
 
 %files tests
-%defattr(-,root,root,-)
-/opt/tests/nemo-qml-plugins/email/*
+/opt/tests/nemo-qml-plugin-email-qt5/*

--- a/rpm/nemo-qml-plugin-email-qt5.spec
+++ b/rpm/nemo-qml-plugin-email-qt5.spec
@@ -42,7 +42,7 @@ Requires:   blts-tools
 
 %build
 %qmake5 "VERSION=%{version}"
-make %{?_smp_mflags}
+%make_build
 
 %install
 %qmake5_install
@@ -58,7 +58,6 @@ sed 's/Nemo.Email/org.nemomobile.email/' < src/plugin/qmldir > %{buildroot}%{_li
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license LICENSE.ASL2 LICENSE.LGPL LICENSE.BSD
 %{_libdir}/libnemoemail-qt5.so.*
 %dir %{_libdir}/qt5/qml/Nemo/Email
@@ -75,12 +74,10 @@ sed 's/Nemo.Email/org.nemomobile.email/' < src/plugin/qmldir > %{buildroot}%{_li
 %{_libdir}/qt5/qml/org/nemomobile/email/qmldir
 
 %files devel
-%defattr(-,root,root,-)
 %{_libdir}/libnemoemail-qt5.so
 %{_libdir}/libnemoemail-qt5.prl
 %{_includedir}/nemoemail-qt5/*.h
 %{_libdir}/pkgconfig/nemoemail-qt5.pc
 
 %files tests
-%defattr(-,root,root,-)
-/opt/tests/nemo-qml-plugins/email/*
+/opt/tests/nemo-qml-plugin-email-qt5/*

--- a/tests/common.pri
+++ b/tests/common.pri
@@ -9,4 +9,4 @@ CONFIG -= app_bundle
 CONFIG += testcase link_pkgconfig
 PKGCONFIG += QmfMessageServer QmfClient
 
-target.path = /opt/tests/nemo-qml-plugins/email
+target.path = /opt/tests/nemo-qml-plugin-email-qt5

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -7,5 +7,5 @@ SUBDIRS = \
 
 tests_xml.target = tests.xml
 tests_xml.files = tests.xml
-tests_xml.path = /opt/tests/nemo-qml-plugins/email
+tests_xml.path = /opt/tests/nemo-qml-plugin-email-qt5/
 INSTALLS += tests_xml

--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -5,13 +5,13 @@
        <set name="unit-tests" feature="QML Email">
            <description>Email QML plugin automatic tests</description>
            <case manual="false" name="emailfolder">
-               <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugins/email/tst_emailfolder</step>
+               <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugin-email-qt5/tst_emailfolder</step>
            </case>
            <case manual="false" name="emailmessage">
-               <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugins/email/tst_emailmessage</step>
+               <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugin-email-qt5/tst_emailmessage</step>
            </case>
            <case manual="false" name="folderlistmodel">
-               <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugins/email/tst_folderlistmodel</step>
+               <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugin-email-qt5/tst_folderlistmodel</step>
            </case>
        </set>
    </suite>

--- a/tests/tst_emailmessage/tst_emailmessage.pro
+++ b/tests/tst_emailmessage/tst_emailmessage.pro
@@ -4,5 +4,5 @@ TARGET = tst_emailmessage
 SOURCES += tst_emailmessage.cpp
 
 attachments.files = attachments/*
-attachments.path = /opt/tests/nemo-qml-plugins/email
+attachments.path = /opt/tests/nemo-qml-plugin-email-qt5
 INSTALLS += attachments


### PR DESCRIPTION
Use just the component name instead of having an inconsistently used container directory for some nemo qml modules.