### PR TITLE
[nemo-email] Adapt to qmf protocolRequest using QVariantMap. JB#63343

### DIFF
--- a/src/emailaction.h
+++ b/src/emailaction.h
@@ -445,7 +445,8 @@ public:
     EasInvitationResponse(QMailProtocolAction* protocolAction,
                           const QMailAccountId &accountId,
                           int response,
-                          const QVariant &responseData);
+                          QMailMessageId message,
+                          QMailMessageId replyMessage);
     ~EasInvitationResponse();
 
     void execute();
@@ -457,7 +458,8 @@ private:
     QMailProtocolAction* _protocolAction;
     QMailAccountId _accountId;
     int _response;
-    QVariant _responseData;
+    QMailMessageId _messageId;
+    QMailMessageId _replyMessageId;
 };
 
 #endif // EMAILACTION_H

--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -1160,6 +1160,14 @@ bool EmailAgent::easCalendarInvitationResponse(const QMailMessage &message,
         return false;
     }
 
+    if (response != InvitationResponseAccept
+            && response != InvitationResponseTentative
+            && response != InvitationResponseDecline) {
+        qCDebug(lcEmail) << "EAS: Invalid calendar response specified";
+        emit calendarInvitationResponded(response, false);
+        return true;
+    }
+
     QMailMessage responseMsg;
     responseMsg.setStatus(QMailMessage::LocalOnly, true);
 
@@ -1186,30 +1194,9 @@ bool EmailAgent::easCalendarInvitationResponse(const QMailMessage &message,
         emit calendarInvitationResponded(response, false);
         return true;
     }
-    QVariantMap data;
-    data.insert("messageId", message.id().toULongLong());
-    QString responseString;
-    switch (response) {
-    case InvitationResponseAccept:
-        responseString = "accept";
-        break;
-    case InvitationResponseTentative:
-        responseString = "tentative";
-        break;
-    case InvitationResponseDecline:
-        responseString = "decline";
-        break;
-    default:
-        qCDebug(lcEmail) << "EAS: Invalid calendar response specified";
-        emit calendarInvitationResponded(response, false);
-        return true;
-    }
-
-    data.insert("response", responseString);
-    data.insert("replyMessageId", responseMsg.id().toULongLong());
 
     enqueue(new EasInvitationResponse(m_protocolAction.data(), message.parentAccountId(),
-                                      response, data));
+                                      response, message.id(), responseMsg.id()));
     exportUpdates(QMailAccountIdList() << message.parentAccountId());
     return true;
 }


### PR DESCRIPTION
Invalid QVariant didn't play nice with D-Bus. While at it adjusted the API to pass QVariantMaps which is slightly nicer to use with this too.

Moved the protocol details to the action class which should be more responsible for them than the EmailAgent.

cc @dcaliste 

Needs https://codereview.qt-project.org/c/qt-labs/messagingframework/+/636335