### PR TITLE
Use the read receipt code from upstream

### DIFF
--- a/rpm/nemo-qml-plugin-email-qt5.spec
+++ b/rpm/nemo-qml-plugin-email-qt5.spec
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(QmfMessageServer) >= 4.0.4+git127
-BuildRequires:  pkgconfig(QmfClient) >= 4.0.4+git156
+BuildRequires:  pkgconfig(QmfClient) >= 4.0.4+git165
 BuildRequires:  pkgconfig(accounts-qt5)
 
 %description

--- a/src/emailmessage.h
+++ b/src/emailmessage.h
@@ -283,8 +283,6 @@ private:
     void insertInlineImages(const QList<QMailMessagePart::Location> &inlineParts);
     const QMailMessagePart *getCalendarPart() const;
     void saveTempCalendarInvitation(const QMailMessagePart &calendarPart);
-    void updateReadReceiptHeader();
-    QString readReceiptRequestEmail() const;
     void setSignatureStatus(SignatureStatus status);
     void setEncryptionStatus(EncryptionStatus status);
 


### PR DESCRIPTION
I'm testing this at the moment.

Compared to the previous implementation, there are two differences I noticed:
- the multipart layout of the previous implementation was wrong, giving a multipart/alternate instead of a multipart/report. This PR makes it better,
- the `Disposition-Notification-To:` header when requesting a disposition notification was previously containing the address only, while now it contains the address in brackets decorated with the name. That's my fault, in QMF, I put address.toString() instead of address.address() in qmailmessage.cpp#8304. I'm not sure it's faulty _wrt._ the RFC though. It is waiting for a value conforming to RFC822. I think the "name <address>" is valid, but not sure… At least with my desktop mailer Claws, I'm getting a warning that the address for the notification "name <address>" is not matching the return path "address". Not sure either if it is over zealous or not.

Besides these two points, it seems to work. It is sending requests that are understood by Claws and Outlook. And it is understanding and properly replying to requests sent by Claws.