### PR TITLE
Add auto configuration of account based on network resources.

### DIFF
--- a/src/emailautoconfig.cpp
+++ b/src/emailautoconfig.cpp
@@ -1,0 +1,375 @@
+/*
+ * Copyright (C) 2025 Jolla Ltd.
+ * Contributor   Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "emailautoconfig.h"
+
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QSettings>
+#include <QTextStream>
+
+#include "logging_p.h"
+
+class ProviderConfig: public QObject
+{
+    Q_OBJECT
+public:
+    ProviderConfig(const QString &provider, QObject *parent)
+        : QObject(parent)
+    {
+        // Liberally inspired by https://wiki.mozilla.org/Thunderbird:Autoconfiguration
+
+        // Try first the provider exposing its configuration.
+        urls << QString::fromLatin1("http://autoconfig.%1/mail/config-v1.1.xml").arg(provider);
+        urls << QString::fromLatin1("http://%1/.well-known/autoconfig/mail/config-v1.1.xml").arg(provider);
+
+        // Fallback to the Thunderbird database of providers. This depends
+        // on Thunderbird database source layout and online service.
+        // It may require to be updated when Thunderbird does some changes.
+        urls << QString::fromLatin1("https://raw.githubusercontent.com/thunderbird/autoconfig/refs/heads/master/ispdb/%1.xml").arg(provider);
+        urls << QString::fromLatin1("https://autoconfig.thunderbird.net/v1.1/%1").arg(provider);
+    }
+
+    ~ProviderConfig() {}
+
+    void fetch(QNetworkAccessManager *manager)
+    {
+        connect(manager, &QNetworkAccessManager::finished,
+                this, [this] (QNetworkReply *reply) {
+                          reply->deleteLater();
+                          if (reply->error() == QNetworkReply::NoError) {
+                              emit fetched(reply->url(), reply);
+                          } else if (!urls.isEmpty()) {
+                              reply->manager()->get(nextRequest());
+                          } else {
+                              emit fetched(QUrl(), nullptr);
+                          }
+                      });
+        manager->get(nextRequest());
+    }
+
+signals:
+    void fetched(QUrl url, QIODevice *config);
+
+private:
+    QNetworkRequest nextRequest()
+    {
+        QNetworkRequest req = QNetworkRequest(QUrl(urls.takeFirst()));
+        req.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+        return req;
+    }
+
+    QStringList urls;
+};
+
+class SettingConfig
+{
+public:
+    SettingConfig(const QString &provider)
+    {
+        QSettings domains(QSettings::SystemScope, "nemo-qml-plugin-email", "domainSettings");
+
+        if (!provider.isEmpty()
+            && domains.contains(provider + QLatin1String("/serviceProvider"))) {
+            domains.beginGroup(provider);
+            QString serviceName = domains.value("serviceProvider").toString();
+
+            QSettings services(QSettings::SystemScope, "nemo-qml-plugin-email", "serviceSettings");
+
+            if (services.contains(serviceName + QLatin1String("/incomingServer"))) {
+                services.beginGroup(serviceName);
+
+                QTextStream buffer(&xmlConfig);
+
+                buffer << "<clientConfig version=\"1.1\">";
+                buffer << "<emailProvider id=\"" << provider << "\">";
+                buffer << "<incomingServer type=\"" << serverType(services.value("incomingServerType").toString()) << "\">";
+                buffer << "<hostname>" << services.value("incomingServer").toString() << "</hostname>";
+                buffer << "<port>" << services.value("incomingPort").toString() << "</port>";
+                buffer << "<socketType>" << securityType(services.value("incomingSecureConnection").toString()) << "</socketType>";
+                // Auth mechanism was not initially present in the settings,
+                // default to plain.
+                buffer << "<authentication>password-cleartext</authentication>";
+                buffer << "</incomingServer>";
+                buffer << "<outgoingServer type=\"smtp\">";
+                buffer << "<hostname>" << services.value("outgoingServer").toString() << "</hostname>";
+                buffer << "<port>" << services.value("outgoingPort").toString() << "</port>";
+                buffer << "<socketType>" << securityType(services.value("outgoingSecureConnection").toString()) << "</socketType>";
+                buffer << "<authentication>" << authorizationType(services.value("outgoingAuthentication").toString()) << "</authentication>";
+                buffer << "</outgoingServer>";
+                buffer << "</emailProvider>";
+                buffer << "</clientConfig>";
+            }
+        }
+    }
+
+    ~SettingConfig() {}
+
+    QByteArray asXML() const
+    {
+        return xmlConfig;
+    }
+
+private:
+    QString serverType(const QString &serverType) {
+        if (serverType.toLower() == QLatin1String("imap4")) {
+            return QLatin1String("imap");
+        } else if (serverType.toLower() == QLatin1String("pop3")) {
+            return QLatin1String("pop3");
+        } else {
+            qCWarning(lcEmail) << "Unknown server type:" << serverType;
+            return serverType;
+        }
+    }
+
+    QString securityType(const QString &securityType) {
+        if (securityType.toLower() == QLatin1String("ssl")) {
+            return QLatin1String("SSL");
+        } else if (securityType.toLower() == QLatin1String("starttls")) {
+            return QLatin1String("STARTTLS");
+        }
+
+        if (securityType.toLower() != QLatin1String("none"))
+            qCWarning(lcEmail) << "Unknown security type:" << securityType;
+        return QLatin1String("plain");
+    }
+
+    QString authorizationType(const QString &authType) {
+        if (authType.toLower() == QLatin1String("login")) {
+            return QLatin1String("password-cleartext"); // Deprecated, replaced by plain
+        } else if (authType.toLower() == QLatin1String("plain")) {
+            return QLatin1String("password-cleartext");
+        } else if (authType.toLower() == QLatin1String("cram-md5")) {
+            return QLatin1String("password-encrypted");
+        }
+
+        if (authType.toLower() != QLatin1String("none"))
+            qCWarning(lcEmail) << "Unknown authorization type:" << authType;
+        return QLatin1String("none");
+    }
+
+    QByteArray xmlConfig;
+};
+
+EmailAutoConfig::EmailAutoConfig(QObject *parent)
+    : QObject(parent)
+    , m_status(Unknown)
+{
+}
+
+EmailAutoConfig::~EmailAutoConfig()
+{
+}
+
+QString EmailAutoConfig::provider() const
+{
+    return m_provider;
+}
+
+void EmailAutoConfig::setProvider(const QString &provider)
+{
+    if (provider == m_provider)
+        return;
+
+    m_provider = provider;
+    emit providerChanged();
+
+    if (m_status != Unknown) {
+        m_status = Unknown;
+        emit statusChanged();
+    }
+    ProviderConfig *xmlFetcher = new ProviderConfig(provider, this);
+    connect(xmlFetcher, &ProviderConfig::fetched,
+            this, [this, xmlFetcher] (QUrl url, QIODevice *config) {
+                      xmlFetcher->deleteLater();
+                      if (config) {
+                          QString errorMsg;
+                          if (m_config.setContent(config, false, &errorMsg)) {
+                              const QDomElement root
+                                  = m_config.firstChildElement(QStringLiteral("clientConfig"));
+                              const QDomElement email
+                                  = root.firstChildElement(QStringLiteral("emailProvider"));
+                              bool matchingDomain = false;
+                              const QDomNodeList domains
+                                  = email.elementsByTagName(QStringLiteral("domain"));
+                              for (int i = 0; !matchingDomain && i < domains.length(); i++) {
+                                  matchingDomain = domains.at(i).toElement().text() == m_provider;
+                              }
+                              if (matchingDomain) {
+                                  m_status = Available;
+                              } else {
+                                  qCWarning(lcEmail) << "wrong autoconfig XML, no matching domain" << m_provider;
+                                  m_status = Unavailable;
+                              }
+                          } else {
+                              qCWarning(lcEmail) << "cannot parse autoconfig:" << errorMsg;
+                              m_status = Unavailable;
+                          }
+                      } else {
+                          m_status = Unavailable;
+                      }
+                      if (m_status == Available) {
+                          m_source = url;
+                      } else {
+                          m_source = QUrl();
+                          // Fallback to local settings.
+                          SettingConfig setting(m_provider);
+                          if (!setting.asXML().isEmpty()
+                              && m_config.setContent(setting.asXML(), false)) {
+                              m_status = Available;
+                          }
+                      }
+                      emit sourceChanged();
+                      emit statusChanged();
+                      emit configChanged();
+                  });
+    xmlFetcher->fetch(&m_manager);
+}
+
+QUrl EmailAutoConfig::source() const
+{
+    return m_source;
+}
+
+EmailAutoConfig::Status EmailAutoConfig::status() const
+{
+    return m_status;
+}
+
+QString EmailAutoConfig::configValue(const QString &tagName, const QString &type,
+                                     const QString &key, const QString &socketType,
+                                     const QString &defaultValue) const
+{
+    if (m_status == Available) {
+        const QDomNodeList elements = m_config.elementsByTagName(tagName);
+        for (int i = 0; i < elements.length(); i++) {
+            const QDomElement keyElement = elements.at(i).firstChildElement(key);
+            const QDomElement socketElement = elements.at(i).firstChildElement(QStringLiteral("socketType"));
+            if (elements.at(i).toElement().attribute(QStringLiteral("type")) == type
+                && !keyElement.isNull()
+                && (socketType.isEmpty() || (socketElement.text() == socketType))) {
+                return keyElement.text();
+            }
+        }
+    }
+    return defaultValue;
+}
+
+QStringList EmailAutoConfig::configList(const QString &tagName, const QString &type,
+                                        const QString &socketType, const QString &key) const
+{
+    QStringList values;
+    if (m_status == Available) {
+        const QDomNodeList elements = m_config.elementsByTagName(tagName);
+        for (int i = 0; i < elements.length(); i++) {
+            const QDomElement socketElement = elements.at(i).firstChildElement(QStringLiteral("socketType"));
+            if (elements.at(i).toElement().attribute(QStringLiteral("type")) == type
+                && (socketType.isEmpty() || (socketElement.text() == socketType))) {
+                const QDomNodeList keys = elements.at(i).toElement().elementsByTagName(key);
+                for (int j = 0; j < keys.length(); j++)
+                    values << keys.at(j).toElement().text();
+                return values;
+            }
+        }
+    }
+    return values;
+}
+
+QString EmailAutoConfig::imapServer() const
+{
+    return configValue(QStringLiteral("incomingServer"), QStringLiteral("imap"),
+                       QStringLiteral("hostname"));
+}
+
+QString EmailAutoConfig::popServer() const
+{
+    return configValue(QStringLiteral("incomingServer"), QStringLiteral("pop3"),
+                       QStringLiteral("hostname"));
+}
+
+QString EmailAutoConfig::smtpServer() const
+{
+    return configValue(QStringLiteral("outgoingServer"), QStringLiteral("smtp"),
+                       QStringLiteral("hostname"));
+}
+
+static const char* socketTypeKeys[] = {"plain", "SSL", "STARTTLS"};
+
+int EmailAutoConfig::imapPort(QMailTransport::EncryptType type) const
+{
+    const QString value
+        = configValue(QStringLiteral("incomingServer"), QStringLiteral("imap"),
+                      QStringLiteral("port"), QString::fromLatin1(socketTypeKeys[type]));
+    bool ok;
+    int port = value.toInt(&ok);
+    return ok ? port : 0;
+}
+
+int EmailAutoConfig::popPort(QMailTransport::EncryptType type) const
+{
+    const QString value
+        = configValue(QStringLiteral("incomingServer"), QStringLiteral("pop3"),
+                      QStringLiteral("port"), QString::fromLatin1(socketTypeKeys[type]));
+    bool ok;
+    int port = value.toInt(&ok);
+    return ok ? port : 0;
+}
+
+int EmailAutoConfig::smtpPort(QMailTransport::EncryptType type) const
+{
+    const QString value
+        = configValue(QStringLiteral("outgoingServer"), QStringLiteral("smtp"),
+                      QStringLiteral("port"), QString::fromLatin1(socketTypeKeys[type]));
+    bool ok;
+    int port = value.toInt(&ok);
+    return ok ? port : 0;
+}
+
+static EmailAutoConfig::AuthList toAuthList(const QStringList &values)
+{
+    EmailAutoConfig::AuthList list;
+    for (const QString &auth : values) {
+        if (auth == QStringLiteral("password-cleartext")) {
+            list << QMail::PlainMechanism;
+        } else if (auth == QStringLiteral("password-encrypted")) {
+            list << QMail::CramMd5Mechanism;
+        } else if (auth == QStringLiteral("OAuth2")) {
+            list << QMail::XOAuth2Mechanism;
+        }
+    }
+    if (list.isEmpty())
+        list << QMail::NoMechanism;
+    return list;
+}
+
+EmailAutoConfig::AuthList EmailAutoConfig::imapAuthentication(QMailTransport::EncryptType type) const
+{
+    return toAuthList(configList(QStringLiteral("incomingServer"),
+                                 QStringLiteral("imap"),
+                                 QString::fromLatin1(socketTypeKeys[type]),
+                                 QStringLiteral("authentication")));
+}
+
+EmailAutoConfig::AuthList EmailAutoConfig::popAuthentication(QMailTransport::EncryptType type) const
+{
+    return toAuthList(configList(QStringLiteral("incomingServer"),
+                                 QStringLiteral("pop3"),
+                                 QString::fromLatin1(socketTypeKeys[type]),
+                                 QStringLiteral("authentication")));
+}
+
+EmailAutoConfig::AuthList EmailAutoConfig::smtpAuthentication(QMailTransport::EncryptType type) const
+{
+    return toAuthList(configList(QStringLiteral("outgoingServer"),
+                                 QStringLiteral("smtp"),
+                                 QString::fromLatin1(socketTypeKeys[type]),
+                                 QStringLiteral("authentication")));
+}
+
+#include "emailautoconfig.moc"

--- a/src/emailautoconfig.h
+++ b/src/emailautoconfig.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2025 Jolla Ltd.
+ * Contributor   Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef EMAILAUTOCONFIG_H
+#define EMAILAUTOCONFIG_H
+
+#include <QObject>
+#include <QNetworkAccessManager>
+#include <QDomDocument>
+#include <QUrl>
+
+#include <qmailtransport.h>
+#include <qmailnamespace.h>
+
+class tst_AutoConfig;
+
+class Q_DECL_EXPORT EmailAutoConfig: public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(Status)
+    Q_PROPERTY(QString provider READ provider WRITE setProvider NOTIFY providerChanged)
+    Q_PROPERTY(QUrl source READ source NOTIFY sourceChanged)
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+
+    Q_PROPERTY(QString imapServer READ imapServer NOTIFY configChanged)
+    Q_PROPERTY(QString popServer READ popServer NOTIFY configChanged)
+    Q_PROPERTY(QString smtpServer READ smtpServer NOTIFY configChanged)
+
+    Q_PROPERTY(int imapPort READ imapPlainPort NOTIFY configChanged)
+    Q_PROPERTY(int imapSSLPort READ imapSSLPort NOTIFY configChanged)
+    Q_PROPERTY(int imapTLSPort READ imapTLSPort NOTIFY configChanged)
+
+    Q_PROPERTY(int popPort READ popPlainPort NOTIFY configChanged)
+    Q_PROPERTY(int popSSLPort READ popSSLPort NOTIFY configChanged)
+    Q_PROPERTY(int popTLSPort READ popTLSPort NOTIFY configChanged)
+
+    Q_PROPERTY(int smtpPort READ smtpPlainPort NOTIFY configChanged)
+    Q_PROPERTY(int smtpSSLPort READ smtpSSLPort NOTIFY configChanged)
+    Q_PROPERTY(int smtpTLSPort READ smtpTLSPort NOTIFY configChanged)
+
+public:
+    enum Status { Unknown, Available, Unavailable };
+
+    typedef QList<QMail::SaslMechanism> AuthList;
+
+    EmailAutoConfig(QObject *parent = nullptr);
+    ~EmailAutoConfig();
+
+    QString provider() const;
+    void setProvider(const QString &provider);
+    QUrl source() const;
+
+    Status status() const;
+
+    QString imapServer() const;
+    QString popServer() const;
+    QString smtpServer() const;
+
+    int imapPort(QMailTransport::EncryptType type) const;
+    int popPort(QMailTransport::EncryptType type) const;
+    int smtpPort(QMailTransport::EncryptType type) const;
+
+    AuthList imapAuthentication(QMailTransport::EncryptType type) const;
+    AuthList popAuthentication(QMailTransport::EncryptType type) const;
+    AuthList smtpAuthentication(QMailTransport::EncryptType type) const;
+
+signals:
+    void providerChanged();
+    void sourceChanged();
+    void statusChanged();
+    void configChanged();
+
+private:
+    QString configValue(const QString &tagName, const QString &type,
+                        const QString &key, const QString &socketType = QString(),
+                        const QString &defaultValue = QString()) const;
+
+    QStringList configList(const QString &tagName, const QString &type,
+                           const QString &socketType, const QString &key) const;
+
+    int imapPlainPort() const {return imapPort(QMailTransport::Encrypt_NONE);}
+    int imapSSLPort() const {return imapPort(QMailTransport::Encrypt_SSL);}
+    int imapTLSPort() const {return imapPort(QMailTransport::Encrypt_TLS);}
+
+    int popPlainPort() const {return popPort(QMailTransport::Encrypt_NONE);}
+    int popSSLPort() const {return popPort(QMailTransport::Encrypt_SSL);}
+    int popTLSPort() const {return popPort(QMailTransport::Encrypt_TLS);}
+
+    int smtpPlainPort() const {return smtpPort(QMailTransport::Encrypt_NONE);}
+    int smtpSSLPort() const {return smtpPort(QMailTransport::Encrypt_SSL);}
+    int smtpTLSPort() const {return smtpPort(QMailTransport::Encrypt_TLS);}
+
+    bool isLocalOnly() const {return m_manager.networkAccessible() != QNetworkAccessManager::Accessible;}
+
+    friend tst_AutoConfig;
+
+    QString m_provider;
+    QUrl m_source;
+    Status m_status;
+    QNetworkAccessManager m_manager;
+    QDomDocument m_config;
+};
+
+Q_DECLARE_METATYPE(EmailAutoConfig::AuthList)
+
+#endif

--- a/src/plugin/plugin.pro
+++ b/src/plugin/plugin.pro
@@ -6,7 +6,7 @@ CONFIG += qt plugin hide_symbols link_pkgconfig
 
 INCLUDEPATH += ..
 
-QT += qml
+QT += qml xml
 PKGCONFIG += QmfMessageServer QmfClient
 LIBS += -L.. -lnemoemail-qt5
 target.path = $$[QT_INSTALL_QML]/$$PLUGIN_IMPORT_PATH

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,5 +1,5 @@
 TEMPLATE = lib
-QT += network dbus concurrent
+QT += network dbus concurrent xml
 CONFIG += link_pkgconfig qt hide_symbols create_pc create_prl
 TARGET = nemoemail-qt5
 PKGCONFIG += QmfMessageServer QmfClient accounts-qt5
@@ -18,6 +18,7 @@ SOURCES += \
     $$PWD/emailaccount.cpp \
     $$PWD/emailaction.cpp \
     $$PWD/emailfolder.cpp \
+    $$PWD/emailautoconfig.cpp \
     $$PWD/attachmentlistmodel.cpp \
     $$PWD/logging.cpp
 
@@ -35,6 +36,7 @@ PRIVATE_HEADERS += \
     $$PWD/emailfolder.h \
     $$PWD/emailmessagelistmodel.h \
     $$PWD/emailutils.h \
+    $$PWD/emailautoconfig.h \
     $$PWD/folderaccessor.h \
     $$PWD/folderlistmodel.h \
     $$PWD/folderlistproxymodel.h \

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -2,8 +2,8 @@ TEMPLATE = subdirs
 SUBDIRS = \
     tst_emailfolder \
     tst_emailmessage \
-    tst_folderlistmodel
-    
+    tst_folderlistmodel \
+    tst_autoconfig
 
 tests_xml.target = tests.xml
 tests_xml.files = tests.xml

--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -13,6 +13,9 @@
            <case manual="false" name="folderlistmodel">
                <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugin-email-qt5/tst_folderlistmodel</step>
            </case>
+           <case manual="false" name="autoconfig">
+               <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugin-email-qt5/tst_autoconfig</step>
+           </case>
        </set>
    </suite>
 </testdefinition>

--- a/tests/tst_autoconfig/tst_autoconfig.cpp
+++ b/tests/tst_autoconfig/tst_autoconfig.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2025 Jolla Ltd.
+ * Contributor   Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <QTest>
+#include <QSignalSpy>
+
+#include "emailautoconfig.h"
+
+class tst_AutoConfig : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void provider_data();
+    void provider();
+};
+
+void tst_AutoConfig::provider_data()
+{
+    QTest::addColumn<QString>("provider");
+    QTest::addColumn<QUrl>("source");
+    QTest::addColumn<QString>("imapServer");
+    QTest::addColumn<QString>("popServer");
+    QTest::addColumn<QString>("smtpServer");
+    QTest::addColumn<int>("imapPort");
+    QTest::addColumn<int>("imapSSLPort");
+    QTest::addColumn<int>("imapTLSPort");
+    QTest::addColumn<int>("popPort");
+    QTest::addColumn<int>("popSSLPort");
+    QTest::addColumn<int>("popTLSPort");
+    QTest::addColumn<int>("smtpPort");
+    QTest::addColumn<int>("smtpSSLPort");
+    QTest::addColumn<int>("smtpTLSPort");
+    QTest::addColumn<EmailAutoConfig::AuthList>("imapAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("imapSSLAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("imapTLSAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("popAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("popSSLAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("popTLSAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("smtpAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("smtpSSLAuthentication");
+    QTest::addColumn<EmailAutoConfig::AuthList>("smtpTLSAuthentication");
+
+    // Autoconfig case, provided by the mail sevice.
+    QTest::newRow("mailbox.org")
+        << "mailbox.org"
+        << QUrl("http://autoconfig.mailbox.org/mail/config-v1.1.xml")
+        << "imap.mailbox.org"
+        << "pop3.mailbox.org"
+        << "smtp.mailbox.org"
+        << 0 << 993 << 143
+        << 0 << 995 << 110
+        << 0 << 465 << 587
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism);
+
+    // No autoconfig by the service, rely on Thunderbird database from Github sources.
+    // This may need update if the service provides autoconfig or Thunderbird
+    // changes its database layout.
+    QTest::newRow("free.fr")
+        << "free.fr"
+        << QUrl("https://raw.githubusercontent.com/thunderbird/autoconfig/refs/heads/master/ispdb/free.fr.xml")
+        << "imap.free.fr"
+        << "pop.free.fr"
+        << "smtp.free.fr"
+        << 0 << 993 << 0
+        << 0 << 995 << 0
+        << 0 << 465 << 0
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism);
+
+    // Same as above.
+    QTest::newRow("studenti.univr.it")
+        << "studenti.univr.it"
+        << QUrl("https://raw.githubusercontent.com/thunderbird/autoconfig/refs/heads/master/ispdb/studenti.univr.it.xml")
+        << "univr.mail.cineca.it"
+        << "univr.mail.cineca.it"
+        << "univr.smtpauth.cineca.it"
+        << 0 << 993 << 0
+        << 0 << 995 << 0
+        << 0 << 465 << 0
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism);
+
+    // Another autoconfig provided by the mail server.
+    QTest::newRow("protonmail.com")
+        << "protonmail.com"
+        << QUrl("https://autoconfig.protonmail.com/mail/config-v1.1.xml")
+        << "127.0.0.1"
+        << ""
+        << "127.0.0.1"
+        << 0 << 0 << 1143
+        << 0 << 0 << 0
+        << 0 << 0 << 1025
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism);
+
+    // No autoconfig by service and provider not in Thunderbird databse,
+    // fallback to local settings.
+    QTest::newRow("1and1.co.uk")
+        << "1and1.co.uk"
+        << QUrl()
+        << "imap.1und1.de"
+        << ""
+        << "smtp.1und1.de"
+        << 0 << 993 << 0
+        << 0 <<   0 << 0
+        << 0 <<   0 << 587
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism);
+
+    // No autoconfig by service, and not a provider on its own,
+    // rely on Thunderbird service mapping the provider to config details.
+    QTest::newRow("nyu.edu")
+        << "nyu.edu"
+        << QUrl("https://autoconfig.thunderbird.net/v1.1/nyu.edu")
+        << "imap.gmail.com"
+        << "pop.gmail.com"
+        << "smtp.gmail.com"
+        << 0 << 993 << 0
+        << 0 << 995 << 0
+        << 0 << 465 << 0
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::XOAuth2Mechanism << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::XOAuth2Mechanism << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::XOAuth2Mechanism << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism);
+}
+
+void tst_AutoConfig::provider()
+{
+    EmailAutoConfig config;
+    QSignalSpy providerChanged(&config, &EmailAutoConfig::providerChanged);
+    QSignalSpy statusChanged(&config, &EmailAutoConfig::statusChanged);
+    QSignalSpy sourceChanged(&config, &EmailAutoConfig::sourceChanged);
+    QSignalSpy configChanged(&config, &EmailAutoConfig::configChanged);
+
+    QVERIFY(config.provider().isEmpty());
+    QVERIFY(config.source().isEmpty());
+    QCOMPARE(config.status(), EmailAutoConfig::Unknown);
+
+    QFETCH(QUrl, source);
+    if (!source.isEmpty() && config.isLocalOnly())
+        QSKIP("network not available");
+
+    QFETCH(QString, provider);
+    config.setProvider(provider);
+    QCOMPARE(providerChanged.count(), 1);
+    QCOMPARE(config.provider(), provider);
+
+    QTRY_COMPARE(statusChanged.count(), 1);
+    QCOMPARE(config.status(), EmailAutoConfig::Available);
+
+    QTRY_COMPARE(sourceChanged.count(), 1);
+    QCOMPARE(config.source(), source);
+
+    QTRY_COMPARE(configChanged.count(), 1);
+    QFETCH(QString, imapServer);
+    QCOMPARE(config.imapServer(), imapServer);
+    QFETCH(QString, popServer);
+    QCOMPARE(config.popServer(), popServer);
+    QFETCH(QString, smtpServer);
+    QCOMPARE(config.smtpServer(), smtpServer);
+    QFETCH(int, imapPort);
+    QCOMPARE(config.imapPort(QMailTransport::Encrypt_NONE), imapPort);
+    QFETCH(int, imapSSLPort);
+    QCOMPARE(config.imapPort(QMailTransport::Encrypt_SSL), imapSSLPort);
+    QFETCH(int, imapTLSPort);
+    QCOMPARE(config.imapPort(QMailTransport::Encrypt_TLS), imapTLSPort);
+    QFETCH(int, popPort);
+    QCOMPARE(config.popPort(QMailTransport::Encrypt_NONE), popPort);
+    QFETCH(int, popSSLPort);
+    QCOMPARE(config.popPort(QMailTransport::Encrypt_SSL), popSSLPort);
+    QFETCH(int, popTLSPort);
+    QCOMPARE(config.popPort(QMailTransport::Encrypt_TLS), popTLSPort);
+    QFETCH(int, smtpPort);
+    QCOMPARE(config.smtpPort(QMailTransport::Encrypt_NONE), smtpPort);
+    QFETCH(int, smtpSSLPort);
+    QCOMPARE(config.smtpPort(QMailTransport::Encrypt_SSL), smtpSSLPort);
+    QFETCH(int, smtpTLSPort);
+    QCOMPARE(config.smtpPort(QMailTransport::Encrypt_TLS), smtpTLSPort);
+    QFETCH(EmailAutoConfig::AuthList, imapAuthentication);
+    QCOMPARE(config.imapAuthentication(QMailTransport::Encrypt_NONE),
+             imapAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, imapSSLAuthentication);
+    QCOMPARE(config.imapAuthentication(QMailTransport::Encrypt_SSL),
+             imapSSLAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, imapTLSAuthentication);
+    QCOMPARE(config.imapAuthentication(QMailTransport::Encrypt_TLS),
+             imapTLSAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, popAuthentication);
+    QCOMPARE(config.popAuthentication(QMailTransport::Encrypt_NONE),
+             popAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, popSSLAuthentication);
+    QCOMPARE(config.popAuthentication(QMailTransport::Encrypt_SSL),
+             popSSLAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, popTLSAuthentication);
+    QCOMPARE(config.popAuthentication(QMailTransport::Encrypt_TLS),
+             popTLSAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, smtpAuthentication);
+    QCOMPARE(config.smtpAuthentication(QMailTransport::Encrypt_NONE),
+             smtpAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, smtpSSLAuthentication);
+    QCOMPARE(config.smtpAuthentication(QMailTransport::Encrypt_SSL),
+             smtpSSLAuthentication);
+    QFETCH(EmailAutoConfig::AuthList, smtpTLSAuthentication);
+    QCOMPARE(config.smtpAuthentication(QMailTransport::Encrypt_TLS),
+             smtpTLSAuthentication);
+}
+
+#include "tst_autoconfig.moc"
+QTEST_MAIN(tst_AutoConfig)

--- a/tests/tst_autoconfig/tst_autoconfig.pro
+++ b/tests/tst_autoconfig/tst_autoconfig.pro
@@ -1,0 +1,4 @@
+include(../common.pri)
+TARGET = tst_autoconfig
+
+SOURCES += tst_autoconfig.cpp


### PR DESCRIPTION
Complement the current auto configuration from
    settings with a network based approach inspired
    by the one used by Thunderbird.
    
    It first check if the domain serving the emails
    is exposing its configuration through an
    autoconfig XML file, otherwise it fallbacks to
    a database used by Thunderbird, maintained on
    Github. For associated domains, it finally
    relies on the autoconfig service hosted by
    Thunderbird.

@pvuorela, this is a proposition to have a better coverage of existing email servers than what the files in `configuration/` can provide. I noted it as a draft to open a discussion, but it's actually usable (but not tested on device yet, just the unit testing). The points I would like to raise are following:
1. I'm proposing an hybrid solution, first based on the existing QSettings files provided here and complementing it by on-line resources,
2. should we simply rely on the QSettings and update them with a script based on these online resources ?
3. should we completely drop the QSettings and only rely on the online resources from device ?

Point 2. has the drawback to require to update it from time to time and miss the advertised config served by provider themselves when they are using the autoconfig mechanism. But it has the advantage to be totally offline on device.

Point 3. has the advantage to completely externalise the autoconfig stuff, but it requires to be online when creating an account from the UI (which may be the case most of the time, just to get the emails for the account).

Point 1. is a middle ground, having the disavantage to maintain a local copy that may not be in sync with the online resources and thus keeping the burden to maintain it.

The changes in the code I'm proposing can easily allow point 3. without much modifications.

I'm also proposing this, because my two providers (free.fr and mailbox.org) are not in the current QSettings. While I can add them easily there, I was trying to get something wider and more future proof. What do you think ?

PS : it is currently based on #35 for ease of testing from my side. It can be rebased on master easily or wait for #35 to be polished and accepted. So just the last commit is relevant here.