### PR TITLE
Accept application/xml for autoconfig, migrate to QRegularExpression

### DIFF
--- a/src/emailaccount.cpp
+++ b/src/emailaccount.cpp
@@ -9,6 +9,7 @@
 #include <QNetworkConfigurationManager>
 #include <QTimer>
 #include <QSettings>
+#include <QRegularExpression>
 
 #include <qmailstore.h>
 #include <qmailmessage.h>
@@ -262,7 +263,7 @@ void EmailAccount::retrieveSettings(const QString &emailAdress)
                       }
                       autoConfig->deleteLater();
                   });
-    autoConfig->setProvider(QString(emailAdress).remove(QRegExp("^.*@")).toLower());
+    autoConfig->setProvider(QString(emailAdress).remove(QRegularExpression("^.*@")).toLower());
 }
 
 void EmailAccount::timeout()
@@ -378,13 +379,13 @@ void EmailAccount::setAddress(const QString &val)
 QString EmailAccount::username() const
 {
     // read-only property, returns username part of email address
-    return address().remove(QRegExp("@.*$"));
+    return address().remove(QRegularExpression("@.*$"));
 }
 
 QString EmailAccount::server() const
 {
     // read-only property, returns server part of email address
-    return address().remove(QRegExp("^.*@"));
+    return address().remove(QRegularExpression("^.*@"));
 }
 
 QString EmailAccount::password() const

--- a/src/emailautoconfig.cpp
+++ b/src/emailautoconfig.cpp
@@ -50,7 +50,8 @@ public:
 
                           if (reply->error() == QNetworkReply::NoError) {
                               QString contentType = reply->header(QNetworkRequest::ContentTypeHeader).toString();
-                              if (contentType.startsWith(QLatin1String("text/xml"))
+                              if (contentType.startsWith(QLatin1String("application/xml"))
+                                      || contentType.startsWith(QLatin1String("text/xml"))
                                       || contentType.startsWith(QLatin1String("text/plain"))) {
                                   emit fetched(reply->url(), reply);
                                   return;

--- a/src/emailmessagelistmodel.cpp
+++ b/src/emailmessagelistmodel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <QDateTime>
+#include <QRegularExpression>
 
 #include <qmailmessage.h>
 #include <qmailmessagekey.h>
@@ -243,12 +244,13 @@ QVariant EmailMessageListModel::data(const QModelIndex & index, int role) const
         // Filter <img> and <ahref> html tags to make the text suitable to be displayed in a qml
         // label using StyledText(allows only small subset of html)
         QString subject = QMailMessageListModel::data(index, QMailMessageModelBase::MessageSubjectTextRole).toString();
-        subject.replace(QRegExp("<\\s*img", Qt::CaseInsensitive), "<no-img");
-        subject.replace(QRegExp("<\\s*a", Qt::CaseInsensitive), "<no-a");
+        subject.replace(QRegularExpression("<\\s*img", QRegularExpression::CaseInsensitiveOption), "<no-img");
+        subject.replace(QRegularExpression("<\\s*a", QRegularExpression::CaseInsensitiveOption), "<no-a");
         return subject;
     } else if (role == MessageTrimmedSubject) {
         QString subject = QMailMessageListModel::data(index, QMailMessageModelBase::MessageSubjectTextRole).toString();
-        return subject.replace(QRegExp(QStringLiteral("^(re:|fw:|fwd:|\\s*)*"), Qt::CaseInsensitive), QString());
+        return subject.replace(QRegularExpression(QStringLiteral("^(re:|fw:|fwd:|\\s*)*"),
+                                                  QRegularExpression::CaseInsensitiveOption), QString());
     } else if (role == MessageHasCalendarCancellationRole) {
         return (messageMetaData.status() & QMailMessageMetaData::CalendarCancellation) != 0;
     } else if (role == MessageRepliedRole) {
@@ -815,6 +817,7 @@ void EmailMessageListModel::onSearchCompleted(const QString &search, const QMail
         qCDebug(lcEmail) << "Search terms are different, skipping. Received:" << search << "Have:" << m_search;
         return;
     }
+
     switch (status) {
     case EmailAgent::SearchDone:
         if (isRemote) {
@@ -835,9 +838,7 @@ void EmailMessageListModel::onSearchCompleted(const QString &search, const QMail
         }
         break;
     case EmailAgent::SearchCanceled:
-        break;
     case EmailAgent::SearchFailed:
-        break;
     default:
         break;
     }


### PR DESCRIPTION
The xml type mismatch was causing a unit test failure.

cc @dcaliste 