### PR TITLE
[nemo-qml-plugin-email] Allow placeholder in <domain> autoconfig.

### DIFF
--- a/src/emailautoconfig.cpp
+++ b/src/emailautoconfig.cpp
@@ -214,7 +214,17 @@ void EmailAutoConfig::setProvider(const QString &provider)
                               const QDomNodeList domains
                                   = email.elementsByTagName(QStringLiteral("domain"));
                               for (int i = 0; !matchingDomain && i < domains.length(); i++) {
-                                  matchingDomain = domains.at(i).toElement().text() == m_provider;
+                                  const QString domain = domains.at(i).toElement().text();
+                                  if (domain == QStringLiteral("%EMAILDOMAIN%")) {
+                                      // https://datatracker.ietf.org/doc/draft-ietf-mailmaint-autoconfig/
+                                      // %EMAILDOMAIN% seems not accepted in <domain> elements,
+                                      // but are sometime used to create a generic
+                                      // config file for providers serving many domains.
+                                      qCWarning(lcEmail) << "%EMAILDOMAIN% placeholder in a <domain> element.";
+                                      matchingDomain = true;
+                                  } else {
+                                      matchingDomain = domain == m_provider;
+                                  }
                               }
                               if (matchingDomain) {
                                   m_status = Available;

--- a/tests/tst_autoconfig/tst_autoconfig.cpp
+++ b/tests/tst_autoconfig/tst_autoconfig.cpp
@@ -175,6 +175,28 @@ void tst_AutoConfig::provider_data()
         << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
         << (EmailAutoConfig::AuthList() << QMail::XOAuth2Mechanism << QMail::PlainMechanism)
         << (EmailAutoConfig::AuthList() << QMail::NoMechanism);
+
+    // Autoconfig file is generic enough to have a %EMAILDOMAIN%
+    // placeholder in the <domain> element. This is generating
+    // a warning since the placeholder is not adviced in this element.
+    QTest::newRow("placeholder in <domain>")
+        << "kakodane.eu"
+        << QUrl("https://autoconfig.kakodane.eu/mail/config-v1.1.xml")
+        << "imap.one.com"
+        << "pop.one.com"
+        << "send.one.com"
+        << 143 << 993 << 0
+        << 110 << 995 << 0
+        << 2525 << 465 << 587
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::NoMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism)
+        << (EmailAutoConfig::AuthList() << QMail::PlainMechanism);
 }
 
 void tst_AutoConfig::provider()


### PR DESCRIPTION
from https://datatracker.ietf.org/doc/draft-ietf-mailmaint-autoconfig/ %EMAILDOMAIN% seems not accepted in <domain> elements, but are sometime used to create a generic
config file for providers serving many domains.

The added test relies on a personal domain using
the ISP mail infrastructure. If this personal
domain disappears, the test could be disabled.