### PR TITLE
[nemo-qml-plugin-email] Timeout only once when testing an account.

### DIFF
--- a/src/emailaccount.cpp
+++ b/src/emailaccount.cpp
@@ -229,6 +229,7 @@ void EmailAccount::test(int timeout)
     if (mAccount->id().isValid()) {
         connect(mTimeoutTimer, &QTimer::timeout,
                 this, &EmailAccount::timeout);
+        mTimeoutTimer->setSingleShot(true);
         mTimeoutTimer->start(timeout * 1000);
         mRetrievalAction->retrieveFolderList(mAccount->id(), QMailFolderId(), true);
     } else {


### PR DESCRIPTION
The timer is by default a multishots, making the
timeout triggered regularly as long as the mail
server is not emitting an error and finishing
succesfully.

@pvuorela, without the QMF fix, the failing authentication is never noticed by the plugin and without the patch, the timeout is triggered at regular interval, requesting to abort the retrieval action.