### PR TITLE
[nemo-qml-plugin-email] Fix memory leaks in Account.

### DIFF
--- a/src/emailaccount.cpp
+++ b/src/emailaccount.cpp
@@ -165,6 +165,8 @@ void EmailAccount::init()
         mRecvType = "pop3";
         mAccountConfig->addServiceConfiguration(mRecvType);
     }
+    delete mSendCfg;
+    delete mRecvCfg;
     mSendCfg = new QMailServiceConfiguration(mAccountConfig, "smtp");
     mRecvCfg = new QMailServiceConfiguration(mAccountConfig, mRecvType);
     mSendCfg->setType(QMailServiceConfiguration::Sink);
@@ -334,8 +336,9 @@ void EmailAccount::setAccountId(const int accId)
 {
     QMailAccountId accountId(accId);
     if (accountId.isValid()) {
-        mAccount = new QMailAccount(accountId);
-        mAccountConfig = new QMailAccountConfiguration(mAccount->id());
+        *mAccount = QMailAccount(accountId);
+        *mAccountConfig = QMailAccountConfiguration(mAccount->id());
+        init();
     } else {
         qCWarning(lcEmail) << "Invalid account id" << accountId.toULongLong();
     }
@@ -477,8 +480,8 @@ bool EmailAccount::pushCapable()
 {
     if (mRecvType.toLower() == "imap4") {
         // Reload configuration since this setting is saved by messageserver
-        mAccountConfig = new QMailAccountConfiguration(mAccount->id());
-        QMailServiceConfiguration imapConf(mAccountConfig, "imap4");
+        QMailAccountConfiguration config(mAccount->id());
+        QMailServiceConfiguration imapConf(config, "imap4");
         return (imapConf.value("pushCapable").toInt() != 0);
     }
 


### PR DESCRIPTION
It's important to remember that QMailServiceConfiguration objects are keeping a pointer on some internals of QMailAccountConfiguration. So changing mAccountConfig should always trigger an init() call to keep
mRecvCfg and mSendCfg up-to-date and not pointing to dangling memory.

@pvuorela, while the leaks seems clear to me, the patch I'm proposing here is not ideal. Would you prefer, to remove the `mRecvCfg` and `mSendCfg` members and reconstruct them on the fly from `mAccountConfig`, whereever they are needed ? Their construction is light and should not create much performance penalty. I'm even wonder if they would suppose to be used like this, and not keeping a pointer or even an instance of them.